### PR TITLE
Fix date filtering fields in services

### DIFF
--- a/src/agendamentos/agendamentos.service.ts
+++ b/src/agendamentos/agendamentos.service.ts
@@ -97,7 +97,7 @@ export class AgendamentosService {
       const endDateTime = new Date(datacriacaoate);
       endDateTime.setUTCHours(23, 59, 59, 999);
 
-      query.datacriacaoa = {
+      query.datacriacao = {
         $lt: endDateTime,
       };
     }

--- a/src/clientes/clientes.service.ts
+++ b/src/clientes/clientes.service.ts
@@ -126,7 +126,7 @@ export class ClientesService {
       const endDateTime = new Date(datacriacaoate);
       endDateTime.setUTCHours(23, 59, 59, 999);
 
-      query.datacriacaoa = {
+      query.datacriacao = {
         $lt: endDateTime
       };
     }

--- a/src/motivos/motivos.service.ts
+++ b/src/motivos/motivos.service.ts
@@ -72,7 +72,7 @@ export class MotivosService {
       const endDateTime = new Date(datacriacaoate);
       endDateTime.setUTCHours(23, 59, 59, 999);
 
-      query.datacriacaoa = {
+      query.datacriacao = {
         $lt: endDateTime,
       };
     }

--- a/src/processos/processos.service.ts
+++ b/src/processos/processos.service.ts
@@ -93,7 +93,7 @@ export class ProcessosService {
       const endDateTime = new Date(datacriacaoate);
       endDateTime.setUTCHours(23, 59, 59, 999);
 
-      query.datacriacaoa = {
+      query.datacriacao = {
         $lt: endDateTime,
       };
     }

--- a/src/status/status.service.ts
+++ b/src/status/status.service.ts
@@ -73,7 +73,7 @@ export class StatusService {
       const endDateTime = new Date(datacriacaoate);
       endDateTime.setUTCHours(23, 59, 59, 999);
 
-      query.datacriacaoa = {
+      query.datacriacao = {
         $lt: endDateTime
       };
     }

--- a/src/usuarios/usuarios.service.ts
+++ b/src/usuarios/usuarios.service.ts
@@ -69,7 +69,7 @@ export class UsuariosService {
       const endDateTime = new Date(datacriacaoate);
       endDateTime.setUTCHours(23, 59, 59, 999);
 
-      query.datacriacaoa = {
+      query.datacriacao = {
         $lt: endDateTime
       };
     }

--- a/src/varas/varas.service.ts
+++ b/src/varas/varas.service.ts
@@ -62,7 +62,7 @@ export class VarasService {
       const endDateTime = new Date(datacriacaoate);
       endDateTime.setUTCHours(23, 59, 59, 999);
 
-      query.datacriacaoa = {
+      query.datacriacao = {
         $lt: endDateTime
       };
     }


### PR DESCRIPTION
## Summary
- fix wrong date filter field `datacriacaoa` in pagination queries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9e0f6a8c8325913da8e6ac2ac381